### PR TITLE
Fixed toolbar mode issue fixed

### DIFF
--- a/ios_inspired/styles.css
+++ b/ios_inspired/styles.css
@@ -7,6 +7,10 @@
 	color: #4c596e;
 }
 
+.ui-page-header-fullscreen .ui-content, .ui-page-footer-fullscreen .ui-content{
+    padding-top: 39px;/* fix for fixed toolbar mode */
+}
+
 /* === HEADER BARS - DEFAULT AND BLACK === */
 .ui-header {
 	-webkit-box-shadow: 0 1px 0 rgba(255,255,255,0.6) inset, 0 -1px 0 rgba(0,0,0,0.6) inset;


### PR DESCRIPTION
in fixed toolbar mode of jQuery mobile 1.1 fixed the text going under
the top bar issue where you can't see the first part of the page
